### PR TITLE
temp fix

### DIFF
--- a/Week0v2/Engine/Source/Runtime/Launch/Define.h
+++ b/Week0v2/Engine/Source/Runtime/Launch/Define.h
@@ -365,6 +365,12 @@ struct alignas(16) FCameraConstants
     float FarPlane;
 };
 
+struct alignas(16) FViewportConstants
+{
+    float ViewportWidth, ViewportHeight;
+    float ViewportOffsetX, ViewportOffsetY;
+};
+
 struct FDepthToWorldConstants
 {
     FMatrix InvView;

--- a/Week0v2/Engine/Source/Runtime/Launch/EditorEngine.cpp
+++ b/Week0v2/Engine/Source/Runtime/Launch/EditorEngine.cpp
@@ -74,14 +74,14 @@ void UEditorEngine::Render()
         {
             LevelEditor->SetViewportClient(i);
             renderer.PrepareRender();
-            renderer.Render(GWorld.get(),LevelEditor->GetActiveViewportClient());
+            renderer.Render(GWorld.get(), LevelEditor->GetActiveViewportClient(), LevelEditor->GetViewports()[i]);
         }
         GetLevelEditor()->SetViewportClient(viewportClient);
     }
     else
     {
         renderer.PrepareRender();
-        renderer.Render(GWorld.get(),LevelEditor->GetActiveViewportClient());
+        renderer.Render(GWorld.get(), LevelEditor->GetActiveViewportClient());
     }
 }
 

--- a/Week0v2/Engine/Source/Runtime/Renderer/Renderer.h
+++ b/Week0v2/Engine/Source/Runtime/Renderer/Renderer.h
@@ -40,6 +40,7 @@ public:
     ID3D11Buffer* SubMeshConstantBuffer = nullptr;
     ID3D11Buffer* TextureConstantBufer = nullptr;
     ID3D11Buffer* CameraConstantBuffer = nullptr;
+    ID3D11Buffer* ViewportConstantBuffer = nullptr;
     ID3D11Buffer* DepthToWorldBuffer = nullptr;
 
     ID3D11BlendState* NormalBlendState = nullptr;
@@ -133,15 +134,16 @@ public: // line shader
     void PrepareRender();
     void ClearRenderArr();
     void Render(UWorld* World, std::shared_ptr<FEditorViewportClient> ActiveViewport);
+    void Render(UWorld* World, std::shared_ptr<FEditorViewportClient> ActiveViewport, std::shared_ptr<FEditorViewportClient> CurrentViewport);
     void RenderStaticMeshes(UWorld* World, std::shared_ptr<FEditorViewportClient> ActiveViewport);
     void RenderGizmos(const UWorld* World, const std::shared_ptr<FEditorViewportClient>& ActiveViewport);
     void RenderLight(UWorld* World, std::shared_ptr<FEditorViewportClient> ActiveViewport);
     void RenderBillboards(UWorld* World,std::shared_ptr<FEditorViewportClient> ActiveViewport);
 
     // post process
-    void RenderPostProcess(UWorld* World, std::shared_ptr<FEditorViewportClient> ActiveViewport);
+    void RenderPostProcess(UWorld* World, std::shared_ptr<FEditorViewportClient> ActiveViewport, std::shared_ptr<FEditorViewportClient> CurrentViewport);
     void RenderDebugDepth(std::shared_ptr<FEditorViewportClient> ActiveViewport);
-    void RenderHeightFog(std::shared_ptr<FEditorViewportClient> ActiveViewport);
+    void RenderHeightFog(std::shared_ptr<FEditorViewportClient> ActiveViewport, std::shared_ptr<FEditorViewportClient> CurrentViewport);
 private:
     TArray<UStaticMeshComponent*> StaticMeshObjs;
     TArray<UGizmoBaseComponent*> GizmoObjs;

--- a/Week0v2/Shaders/DebugDepthShader.hlsl
+++ b/Week0v2/Shaders/DebugDepthShader.hlsl
@@ -11,6 +11,12 @@ cbuffer CameraConstant : register(b0)
     float FarPlane;
 };
 
+cbuffer ViewportInfo : register(b1)
+{
+    float2 ViewportSize;
+    float2 ViewportOffset;
+}
+
 Texture2D<float> SceneDepthTex : register(t0);
 SamplerState PointSampler : register(s0);
 
@@ -50,7 +56,9 @@ VS_OUT mainVS(uint id : SV_VertexID)
 
 float4 mainPS(VS_OUT input) : SV_Target
 {
-    float depth = SceneDepthTex.Sample(PointSampler, input.uv).r;
+    float2 viewportUV = input.uv * ViewportSize + ViewportOffset;
+    
+    float depth = SceneDepthTex.Sample(PointSampler, viewportUV).r;
     if (depth == 1.0)
     {
         return float4(0, 0, 0, 1);

--- a/Week0v2/Shaders/HeightFogPixelShader.hlsl
+++ b/Week0v2/Shaders/HeightFogPixelShader.hlsl
@@ -11,6 +11,12 @@ cbuffer CameraConstant : register(b0)
     float FarPlane;
 };
 
+cbuffer ViewportInfo : register(b1)
+{
+    float2 ViewportSize;
+    float2 ViewportOffset;
+}
+
 cbuffer FogParams : register(b6)
 {
     float FogDensity;
@@ -61,8 +67,9 @@ struct VS_OUT
 
 float4 mainPS(VS_OUT input) : SV_TARGET
 {
-    float4 sceneColor = SceneTexture.Sample(SamplerLinear, input.uv);
-    float depth = DepthTexture.Sample(SamplerLinear, input.uv).r;
+    float2 viewportUV = input.uv * ViewportSize + ViewportOffset;
+    float4 sceneColor = SceneTexture.Sample(SamplerLinear, viewportUV);
+    float depth = DepthTexture.Sample(SamplerLinear, viewportUV).r;
     
     float linearDepth = (NearPlane * FarPlane) / (FarPlane - depth * (FarPlane - NearPlane));
     float normalized = saturate((linearDepth - DistanceFogNear) / (DistanceFotFar - DistanceFogNear));


### PR DESCRIPTION
- depth 사용 시 화면이 분할되는 현상 임시 수정 
- 현재 Activeviewport가 변경 시 해당 Viewport에서의 depth buffer를 가져오고 있어 Active가 변경될 때 fog등 depth를 사용하는 scene이 다르게 렌더링 됨

- RTV자체를 분할된 화면마다 별도로 사용하는 방식으로 수정하는 것이 좋을듯